### PR TITLE
Add option to skip MSVC exceptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ if(MSVC)
     endforeach()
 
     # Enable Unicode
-    add_definitions(-D_UNICODE -DUNICODE)
+    add_definitions(-D_UNICODE -DUNICODE -D_HAS_EXCEPTIONS=0)
 
 elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL GNU OR ${CMAKE_CXX_COMPILER_ID} STREQUAL Clang)
 


### PR DESCRIPTION
Resolves #4. VS2017's `xlocale` header is causing problems due to having exception code within it. Defining `_HAS_EXCEPTIONS=0` causes the header to revert to an exceptionless path.