### PR TITLE
Allow multiple integer command-line options

### DIFF
--- a/include/qflags/integer_option.hpp
+++ b/include/qflags/integer_option.hpp
@@ -37,7 +37,7 @@ QFLAGS_INLINE int integer_option::parse(int argc, char const* const* argv, std::
 
     int argn = _parse_integer(argc, argv, &_value_string, &_value_integer, errors);
 
-    _is_set = (argn > 0) ? true : false;
+    _is_set |= (argn > 0) ? true : false;
 
     return argn;
 }


### PR DESCRIPTION
We ran into an issue where doing something like this
```
<my command> -a 20 -b 40
```
(where `a` and `b` are the short form of the two integer options defined in code) would result in only one of these options returning `true` from `is_set()`. This fixes this for integer options, not sure if others have the same problem (we don't seem to have this issue with multiple string options, for example).