### PR TITLE
 Check and reset `is_set` property during parsing

### DIFF
--- a/include/qflags/boolean_option.hpp
+++ b/include/qflags/boolean_option.hpp
@@ -35,9 +35,9 @@ QFLAGS_INLINE int boolean_option::parse(int argc, char const* const* argv, std::
     assert(argv && "argv must not be null!");
     assert(errors && "errors must not be null!");
 
-    int argn = _parse_boolean(argc, argv, &_value_string, &_value_boolean, errors);
+    int argn = _is_set ? 0 : _parse_boolean(argc, argv, &_value_string, &_value_boolean, errors);
 
-    _is_set = (argn > 0) ? true : false;
+    _is_set |= (argn > 0) ? true : false;
 
     return argn;
 }

--- a/include/qflags/choice_option.hpp
+++ b/include/qflags/choice_option.hpp
@@ -66,7 +66,7 @@ QFLAGS_INLINE int choice_option::parse(int argc, char const* const* argv, std::s
     assert(errors && "errors must not be null!");
 
     // Check if argument could be parsed as any string.
-    int argn = _parse_string(argc, argv, &_value_string, errors);
+    int argn = _is_set ? 0 : _parse_string(argc, argv, &_value_string, errors);
 
     if (argn > 0) {
         // Check that the argument value is valid.

--- a/include/qflags/integer_option.hpp
+++ b/include/qflags/integer_option.hpp
@@ -35,9 +35,9 @@ QFLAGS_INLINE int integer_option::parse(int argc, char const* const* argv, std::
     assert(argv && "argv must not be null!");
     assert(errors && "errors must not be null!");
 
-    int argn = _parse_integer(argc, argv, &_value_string, &_value_integer, errors);
+    int argn = _is_set ? 0 : _parse_integer(argc, argv, &_value_string, &_value_integer, errors);
 
-    _is_set = (argn > 0) ? true : false;
+    _is_set |= (argn > 0) ? true : false;
 
     return argn;
 }

--- a/include/qflags/parser.hpp
+++ b/include/qflags/parser.hpp
@@ -214,6 +214,11 @@ QFLAGS_INLINE bool parser::parse(command_line const& command_line, std::string* 
     std::vector<char const*> argv(_command_line.argv(),
                                   _command_line.argv() + argc);
 
+    // Reset all arguments
+    for (auto& arg : _arguments) {
+        arg.second->_is_set = false;
+    }
+
     for (size_t ii = 0; ii < argv.size();) {
         // Arg is a short flag or group of short flags.
         if (argv[ii][0] == '-' && argv[ii][1] != '-') {

--- a/include/qflags/qflags.h
+++ b/include/qflags/qflags.h
@@ -978,6 +978,7 @@ inline int repeated_option<base_option>::parse(int argc,
 {
     // Temporary option for parsing.
     base_option swap_option = *this;
+    base_option::_is_set = false;
 
     // Parse the argument using the base option type.
     int argn = base_option::parse(argc, argv, errors);

--- a/include/qflags/range_option.hpp
+++ b/include/qflags/range_option.hpp
@@ -71,7 +71,7 @@ QFLAGS_INLINE int range_option::parse(int argc, char const* const* argv, std::st
     assert(errors && "errors must not be null!");
 
     // Check if argument could be parsed as any integer.
-    int argn = _parse_integer(argc, argv, &_value_string, &_value_integer, errors);
+    int argn = _is_set ? 0 : _parse_integer(argc, argv, &_value_string, &_value_integer, errors);
 
     if (argn > 0) {
         // Check that the argument value is valid.

--- a/include/qflags/string_option.hpp
+++ b/include/qflags/string_option.hpp
@@ -35,9 +35,9 @@ QFLAGS_INLINE int string_option::parse(int argc, char const* const* argv, std::s
     assert(argv && "argv must not be null!");
     assert(errors && "errors must not be null!");
 
-    int argn = _parse_string(argc, argv, &_value_string, errors);
+    int argn = _is_set ? 0 : _parse_string(argc, argv, &_value_string, errors);
 
-    _is_set = (argn > 0) ? true : false;
+    _is_set |= (argn > 0) ? true : false;
 
     return argn;
 }

--- a/test/parser.cpp
+++ b/test/parser.cpp
@@ -182,3 +182,29 @@ TEST(parser_test, parse_duplicate_flags)
     EXPECT_EQ(true, parser.parse(command_line, &errors));
     EXPECT_NE(0u, errors.length());
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/**
+ * Test that `is_set` is set properly after parsing.
+ */
+TEST(parser_test, parse_is_set)
+{
+    char const* argv[] = { "-a", "10", "-b", "20" };
+    auto command_line = qflags::command_line(argv);
+
+    auto parser = qflags::parser();
+
+    std::string errors;
+
+    auto foo = qflags::integer_option("foo", "a");
+    auto bar = qflags::integer_option("bar", "b");
+
+    ASSERT_EQ(true, parser.add_argument(&foo));
+    ASSERT_EQ(true, parser.add_argument(&bar));
+    ASSERT_EQ(true, parser.parse(command_line,&errors));
+
+    EXPECT_TRUE(foo.is_set());
+    EXPECT_EQ(10, static_cast<int>(foo));
+    EXPECT_TRUE(bar.is_set());
+    EXPECT_EQ(20, static_cast<int>(bar));
+}


### PR DESCRIPTION
Previously it was possible for arguments to become unset during parsing
due each argument object being evaluated for each argument string in the
command line. This change adds checks to each argument affected by the
issue for whether the argument is already set. In order to allow parsers
to be re-used, the `is_set` property of each argument is reset at the
beginning of each command line parsing.
